### PR TITLE
Modified k8s yaml files

### DIFF
--- a/k8s/citizenapi-deployment.yaml
+++ b/k8s/citizenapi-deployment.yaml
@@ -20,10 +20,15 @@ spec:
     spec:
       containers:
         - name: citizenapi
-          image: mcpacr2.azurecr.io/citizenapi:v4
+          image: mpapas/citizenapi:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8081
-          resources: {}
+          resources:
+            limits:
+              memory: 600Mi
+            requests:
+              memory: 300Mi
           env:
             - name: MONGO_CONNECTION_STRING
               valueFrom:

--- a/k8s/generators/latency-generator-deployment.yaml
+++ b/k8s/generators/latency-generator-deployment.yaml
@@ -19,7 +19,8 @@ spec:
         app: latency-generator
     spec:
       containers:
-        - image: mcpacr2.azurecr.io/latencygenerator:v2
+        - image: mpapas/latencygenerator:latest
+          imagePullPolicy: Always
           name: latency-generator
           resources: {}
       restartPolicy: Always

--- a/k8s/generators/load-generator-deployment.yaml
+++ b/k8s/generators/load-generator-deployment.yaml
@@ -19,7 +19,8 @@ spec:
         app: load-generator
     spec:
       containers:
-        - image: mcpacr2.azurecr.io/loadgenerator:v1
+        - image: mpapas/loadgenerator:latest
+          imagePullPolicy: Always
           name: load-generator
           resources: {}
       restartPolicy: Always

--- a/k8s/generators/memory-leak-generator-deployment.yaml
+++ b/k8s/generators/memory-leak-generator-deployment.yaml
@@ -19,7 +19,8 @@ spec:
         app: memory-leak-generator
     spec:
       containers:
-        - image: mcpacr2.azurecr.io/memoryleakgenerator:v2
+        - image: mpapas/memoryleakgenerator:latest
+          imagePullPolicy: Always
           name: memory-leak-generator
           resources: {}
       restartPolicy: Always

--- a/k8s/mongo/mongodb-pvc.yaml
+++ b/k8s/mongo/mongodb-pvc.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce 
-  storageClassName: managed-csi-premium
   resources:
     requests:
       storage: 1Gi

--- a/k8s/resourceapi-deployment.yaml
+++ b/k8s/resourceapi-deployment.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: resourceapi
-          image: mcpacr2.azurecr.io/resourceapi:v4
+          image: mpapas/resourceapi:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8082
           resources: {}


### PR DESCRIPTION
- Switched to use a public docker hub repo for the app images vs. an ACR repo to make it easier to pull images onto k8s clusters in other clouds. 
- Removed the Azure-specific storage class reference for the PVC.
- Updated the image pull policy for the app images.
